### PR TITLE
[dcp-497] Set accession on entity's attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='submission-broker',
-    version='0.1.1',
+    version='0.1.2',
     description="A library written in Python to handle brokering submission into EBI archives.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/submission_broker/submission/entity.py
+++ b/submission_broker/submission/entity.py
@@ -42,6 +42,7 @@ class Entity:
 
     def add_accession(self, service: str, accession_value: str):
         self.__accessions[service] = accession_value
+        self.attributes.update({'accession': accession_value})
 
     def get_accession(self, service: str) -> str:
         return self.__accessions.get(service, None)

--- a/tests/unit/submission_broker/submission/test_submission_accessions.py
+++ b/tests/unit/submission_broker/submission/test_submission_accessions.py
@@ -9,6 +9,8 @@ class TestSubmissionAccessions(unittest.TestCase):
         self.maxDiff = None
         self.__setup_mock_entities()
 
+        self.biostudies_accession = "BST1"
+
     def test_when_entities_has_accessions_returns_them_by_type(self):
         expected_accession_by_type = {
             'BioSamples': {'SAME123', 'SAME456', 'SAME789'},
@@ -18,7 +20,7 @@ class TestSubmissionAccessions(unittest.TestCase):
         submission = Submission()
 
         study = submission.map("study", "study", self.study)
-        study.add_accession('BioStudies', "BST1")
+        study.add_accession('BioStudies', self.biostudies_accession)
 
         sample1 = submission.map("sample", "sample1", self.sample1)
         sample1.add_accession('BioSamples', "SAME123")
@@ -33,6 +35,14 @@ class TestSubmissionAccessions(unittest.TestCase):
         run_experiment.add_accession('ENA', "EXP123")
 
         self.assertEqual(expected_accession_by_type, submission.get_all_accessions())
+
+    def test_when_add_accession_to_entity_then_accession_set_in_attributes(self):
+        submission = Submission()
+
+        study = submission.map("study", "study", self.study)
+        study.add_accession('BioStudies', self.biostudies_accession)
+
+        self.assertEqual(study.attributes.get('accession'), self.biostudies_accession)
 
     def __setup_mock_entities(self):
         self.study = {


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#497

Changes:
- Set accession on entity's attributes