### PR TITLE
[dcp-581] Revert accession field setting on entity's attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='submission-broker',
-    version='0.1.2',
+    version='0.2.0',
     description="A library written in Python to handle brokering submission into EBI archives.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/submission_broker/submission/entity.py
+++ b/submission_broker/submission/entity.py
@@ -42,7 +42,6 @@ class Entity:
 
     def add_accession(self, service: str, accession_value: str):
         self.__accessions[service] = accession_value
-        self.attributes.update({'accession': accession_value})
 
     def get_accession(self, service: str) -> str:
         return self.__accessions.get(service, None)

--- a/tests/unit/submission_broker/submission/test_submission_accessions.py
+++ b/tests/unit/submission_broker/submission/test_submission_accessions.py
@@ -36,14 +36,6 @@ class TestSubmissionAccessions(unittest.TestCase):
 
         self.assertEqual(expected_accession_by_type, submission.get_all_accessions())
 
-    def test_when_add_accession_to_entity_then_accession_set_in_attributes(self):
-        submission = Submission()
-
-        study = submission.map("study", "study", self.study)
-        study.add_accession('BioStudies', self.biostudies_accession)
-
-        self.assertEqual(study.attributes.get('accession'), self.biostudies_accession)
-
     def __setup_mock_entities(self):
         self.study = {
             "study_accession": "PRJEB12345",


### PR DESCRIPTION
Changes:
- Revert accession field setting on entity's attribute

Previously I added that line what I am reverting now. I think I was confused at that time and I thought we should set the accession field on the entity, but after some discussion it turned out that the `accession` field is a deprecated field and we should not use it.